### PR TITLE
Close response body after finished

### DIFF
--- a/getobject.go
+++ b/getobject.go
@@ -50,6 +50,7 @@ func (obj *GetObject) Content() ([]byte, error) {
 		return obj.Blob, nil
 	}
 	resp, err := http.Get(obj.Location)
+	defer resp.Body.Close()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Close the response body to before leaving the Content method to keep sockets from backing up.
