### PR TITLE
Enable overloading CharsetReader for different encodings

### DIFF
--- a/login.go
+++ b/login.go
@@ -45,7 +45,7 @@ func (s *Session) Login(url string) (*CapabilityUrls, error) {
 
 	urls, err := parseCapability(url, capabilities)
 	if err != nil {
-		return nil, errors.New("unable to parse capabilites response: " + string(capabilities))
+		return nil, errors.New("unable to parse capabilites response: " + string(capabilities) + " Error: " + err.Error())
 	}
 	return urls, nil
 }
@@ -59,8 +59,7 @@ func parseCapability(url string, response []byte) (*CapabilityUrls, error) {
 	}
 
 	rets := XmlRets{}
-	decoder := xml.NewDecoder(bytes.NewBuffer(response))
-	decoder.Strict = false
+	decoder := GetXmlReader(bytes.NewBuffer(response), false)
 	err := decoder.Decode(&rets)
 	if err != nil && err != io.EOF {
 		return nil, err

--- a/xml_helper.go
+++ b/xml_helper.go
@@ -1,0 +1,17 @@
+package gorets_client
+
+import (
+	"encoding/xml"
+	"io"
+)
+
+var SelectedCharsetReader func(string, io.Reader) (io.Reader, error) = nil
+
+func GetXmlReader(input io.Reader, strict bool) *xml.Decoder {
+	decoder := xml.NewDecoder(input)
+	if SelectedCharsetReader != nil {
+		decoder.CharsetReader = SelectedCharsetReader
+	}
+	decoder.Strict = strict
+	return decoder
+}


### PR DESCRIPTION
This exposes a point where an external program can overload the CharsetReader with any function they like. If a function hasn't been set, then we don't override this.

We'll have to set this in other places, but this is the solution for the general problem.
