### PR TITLE
Enable travis-ci for Go 1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: go
 
 go:
   - 1.3
+  - 1.4
   - tip


### PR DESCRIPTION
Enable CI for Go 1.4 in addition to 1.3 and tip.
