### PR TITLE
parseCapability recognize empty rets response when xml is pretty printed

### DIFF
--- a/client/login.go
+++ b/client/login.go
@@ -69,7 +69,7 @@ func parseCapability(body io.ReadCloser, url string) (*CapabilityURLs, error) {
 	if err != nil && err != io.EOF {
 		return nil, err
 	}
-	if rets.Response == "" {
+	if strings.TrimSpace(rets.Response) == "" {
 		return nil, errors.New("failed to read urls")
 	}
 


### PR DESCRIPTION
An empty rets response in pretty printed XML is being parsed as a newline character.