### PR TITLE
compose SearchRequest from SearchParams + everything else

### DIFF
--- a/cmds/search/main.go
+++ b/cmds/search/main.go
@@ -59,16 +59,18 @@ func main() {
 
 	fmt.Println("Search: ", capability.Search)
 	req := rets.SearchRequest{
-		URL:        capability.Search,
-		Select:     searchOpts.Select,
-		Query:      searchOpts.Query,
-		SearchType: searchOpts.Resource,
-		Class:      searchOpts.Class,
-		Format:     searchOpts.Format,
-		QueryType:  searchOpts.QueryType,
-		Count:      searchOpts.CountType,
-		Limit:      searchOpts.Limit,
-		// Offset:     -1,
+		URL: capability.Search,
+		SearchParams: rets.SearchParams{
+			Select:     searchOpts.Select,
+			Query:      searchOpts.Query,
+			SearchType: searchOpts.Resource,
+			Class:      searchOpts.Class,
+			Format:     searchOpts.Format,
+			QueryType:  searchOpts.QueryType,
+			Count:      searchOpts.CountType,
+			Limit:      searchOpts.Limit,
+			// Offset:     -1,
+		},
 	}
 
 	w := csv.NewWriter(os.Stdout)

--- a/rets/search.go
+++ b/rets/search.go
@@ -19,9 +19,8 @@ const (
 
 // TODO include standard names constants here
 
-// SearchRequest ...
-type SearchRequest struct {
-	URL,
+// SearchParams ...
+type SearchParams struct {
 	Class,
 	SearchType,
 	Format, // 7.4.2 COMPACT | COMPACT-DECODED | STANDARD-XML
@@ -29,13 +28,20 @@ type SearchRequest struct {
 	Query,
 	QueryType,
 	RestrictedIndicator,
-	Payload, //The Client may request a specific XML format for the return set.
-	HTTPMethod string
+	Payload string //The Client may request a specific XML format for the return set.
 
 	Count,
-	// TODO NONE is a valid option, this needs to be modified
-	Limit,
+	Limit, // <0 => "NONE"
 	Offset int
+}
+
+// SearchRequest ...
+type SearchRequest struct {
+	URL,
+	HTTPMethod string
+
+	SearchParams
+
 	BufferSize int // TODO unused atm
 }
 


### PR DESCRIPTION
Proposing a breaking change for `SearchRequest` builders, readers are unaffected.