### PR TITLE
separate request prep from execution

### DIFF
--- a/cmds/getobject/main.go
+++ b/cmds/getobject/main.go
@@ -61,10 +61,12 @@ func main() {
 	fmt.Println("GetObject: ", capability.GetObject)
 	// warning, this does _all_ of the photos
 	response, err := rets.GetObjects(session, ctx, rets.GetObjectRequest{
-		URL:      capability.GetObject,
-		Resource: getOptions.Resource,
-		Type:     getOptions.Type,
-		ID:       getOptions.ID,
+		URL: capability.GetObject,
+		GetObjectParams: rets.GetObjectParams{
+			Resource: getOptions.Resource,
+			Type:     getOptions.Type,
+			ID:       getOptions.ID,
+		},
 	})
 	if err != nil {
 		panic(err)

--- a/explorer/object.go
+++ b/explorer/object.go
@@ -50,10 +50,12 @@ func (os ObjectService) Get(r *http.Request, args *ObjectParams, reply *Objects)
 	return s.Exec(ctx, func(r rets.Requester, u rets.CapabilityURLs) error {
 		// warning, this does _all_ of the photos
 		response, err := rets.GetObjects(r, ctx, rets.GetObjectRequest{
-			URL:      u.GetObject,
-			Resource: args.Resource,
-			Type:     args.Type,
-			ID:       args.ObjectID,
+			URL: u.GetObject,
+			GetObjectParams: rets.GetObjectParams{
+				Resource: args.Resource,
+				Type:     args.Type,
+				ID:       args.ObjectID,
+			},
 		})
 		if err != nil {
 			return err

--- a/rets/get_payload_list.go
+++ b/rets/get_payload_list.go
@@ -14,11 +14,11 @@ type PayloadListRequest struct {
 	URL, HTTPMethod, ID string
 }
 
-// GetPayloadList ...
-func GetPayloadList(requester Requester, ctx context.Context, r PayloadListRequest) (PayloadList, error) {
+// PrepGetPayloadList creates an http.Request from a PayloadListRequest
+func PrepGetPayloadList(r PayloadListRequest) (*http.Request, error) {
 	url, err := url.Parse(r.URL)
 	if err != nil {
-		return PayloadList{}, err
+		return nil, err
 	}
 	values := url.Query()
 	// required
@@ -30,7 +30,12 @@ func GetPayloadList(requester Requester, ctx context.Context, r PayloadListReque
 	}
 	url.RawQuery = values.Encode()
 
-	req, err := http.NewRequest(method, url.String(), nil)
+	return http.NewRequest(method, url.String(), nil)
+}
+
+// GetPayloadList ...
+func GetPayloadList(requester Requester, ctx context.Context, r PayloadListRequest) (PayloadList, error) {
+	req, err := PrepGetPayloadList(r)
 	if err != nil {
 		return PayloadList{}, err
 	}

--- a/rets/getobject.go
+++ b/rets/getobject.go
@@ -101,10 +101,8 @@ func (r *GetObjectResponse) Close() error {
 // GetObjectResult ...
 type GetObjectResult func(*Object, error) error
 
-// GetObjectRequest ...
-type GetObjectRequest struct {
-	/* 5.3 */
-	URL, HTTPMethod,
+// GetObjectParams
+type GetObjectParams struct {
 	Resource,
 	Type,
 	UID,
@@ -114,4 +112,12 @@ type GetObjectRequest struct {
 	ObjectData []string
 	/* 5.4.1 */
 	Location int
+}
+
+// GetObjectRequest ...
+type GetObjectRequest struct {
+	/* 5.3 */
+	URL,
+	HTTPMethod string
+	GetObjectParams
 }

--- a/rets/getobject.go
+++ b/rets/getobject.go
@@ -12,8 +12,8 @@ import (
 	"context"
 )
 
-// GetObjects ...
-func GetObjects(requester Requester, ctx context.Context, r GetObjectRequest) (*GetObjectResponse, error) {
+// PrepGetObjects creates an http.Request from a GetObjectRequest
+func PrepGetObjects(r GetObjectRequest) (*http.Request, error) {
 	url, err := url.Parse(r.URL)
 	if err != nil {
 		return nil, err
@@ -43,7 +43,12 @@ func GetObjects(requester Requester, ctx context.Context, r GetObjectRequest) (*
 
 	url.RawQuery = values.Encode()
 
-	req, err := http.NewRequest(method, url.String(), nil)
+	return http.NewRequest(method, url.String(), nil)
+}
+
+// GetObjects ...
+func GetObjects(requester Requester, ctx context.Context, r GetObjectRequest) (*GetObjectResponse, error) {
+	req, err := PrepGetObjects(r)
 	if err != nil {
 		return nil, err
 	}

--- a/rets/metadata.go
+++ b/rets/metadata.go
@@ -14,8 +14,8 @@ type MetadataRequest struct {
 	URL, HTTPMethod, Format, MType, ID string
 }
 
-// MetadataStream ...
-func MetadataStream(requester Requester, ctx context.Context, r MetadataRequest) (io.ReadCloser, error) {
+// PrepMetadataRequest creates an http.Request from a MetadataRequest
+func PrepMetadataRequest(r MetadataRequest) (*http.Request, error) {
 	url, err := url.Parse(r.URL)
 	if err != nil {
 		return nil, err
@@ -33,7 +33,12 @@ func MetadataStream(requester Requester, ctx context.Context, r MetadataRequest)
 
 	url.RawQuery = values.Encode()
 
-	req, err := http.NewRequest(method, url.String(), nil)
+	return http.NewRequest(method, url.String(), nil)
+}
+
+// MetadataStream ...
+func MetadataStream(requester Requester, ctx context.Context, r MetadataRequest) (io.ReadCloser, error) {
+	req, err := PrepMetadataRequest(r)
 	if err != nil {
 		return nil, err
 	}

--- a/rets/search.go
+++ b/rets/search.go
@@ -47,8 +47,8 @@ type SearchRequest struct {
 	BufferSize int // TODO unused atm
 }
 
-// SearchStream ...
-func SearchStream(requester Requester, ctx context.Context, r SearchRequest) (io.ReadCloser, error) {
+// PrepSearchRequest creates an http.Request from a SearchRequest
+func PrepSearchRequest(r SearchRequest) (*http.Request, error) {
 	url, err := url.Parse(r.URL)
 	if err != nil {
 		return nil, err
@@ -87,7 +87,12 @@ func SearchStream(requester Requester, ctx context.Context, r SearchRequest) (io
 
 	url.RawQuery = values.Encode()
 
-	req, err := http.NewRequest(method, url.String(), nil)
+	return http.NewRequest(method, url.String(), nil)
+}
+
+// SearchStream ...
+func SearchStream(requester Requester, ctx context.Context, r SearchRequest) (io.ReadCloser, error) {
+	req, err := PrepSearchRequest(r)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Goal here is to make the raw http request available to clients who don't want to use the higher level `SearchStream` `GetObjects` ... methods

Contains backwards incompatible change to GetObject request creation similar to #40.

