### PR TITLE
Fix racy read/increment of digest NonceCount

### DIFF
--- a/rets/digest_test.go
+++ b/rets/digest_test.go
@@ -6,6 +6,7 @@ package rets
 
 import (
 	"crypto/md5"
+	"sync"
 	"testing"
 
 	testutils "github.com/jpfielding/gotest/testutils"
@@ -26,6 +27,7 @@ func TestParseChallenge(t *testing.T) {
 		Opaque:     "6e6f742075736564",
 		Qop:        "",
 		NonceCount: 1,
+		m:          &sync.Mutex{},
 	}
 
 	testutils.Equals(t, expected, digest)
@@ -131,6 +133,7 @@ func createNoQopDigest() *Digest {
 		Opaque:     "6e6f742075736564",
 		Qop:        "",
 		NonceCount: 1,
+		m:          &sync.Mutex{},
 	}
 }
 
@@ -142,5 +145,6 @@ func createAuthDigest() *Digest {
 		Opaque:     "6e6f742075736564",
 		Qop:        "auth",
 		NonceCount: 1,
+		m:          &sync.Mutex{},
 	}
 }


### PR DESCRIPTION
Simultaneous calls to session(ctx, req)
```
==================
WARNING: DATA RACE
Write at 0x00c420020110 by goroutine 25:
  github.com/jpfielding/gorets/rets.(*Digest).computeAuthorization()
      /var/www/html/support-chat/src/github.com/jpfielding/gorets/rets/digest.go:145 +0xdb9
  github.com/jpfielding/gorets/rets.(*Digest).CreateDigestResponse()
      /var/www/html/support-chat/src/github.com/jpfielding/gorets/rets/digest.go:151 +0xd2
  github.com/jpfielding/gorets/rets.(*WWWAuthTransport).header()
      /var/www/html/support-chat/src/github.com/jpfielding/gorets/rets/www_auth.go:25 +0x10b
  github.com/jpfielding/gorets/rets.(*WWWAuthTransport).Request()
      /var/www/html/support-chat/src/github.com/jpfielding/gorets/rets/www_auth.go:33 +0x8a
  github.com/jpfielding/gorets/rets.(*WWWAuthTransport).Request-fm()
      /var/www/html/support-chat/src/github.com/jpfielding/gorets/rets/client.go:64 +0x63
  github.com/jpfielding/gorets/rets.(*UserAgentAuthentication).Request()
      /var/www/html/support-chat/src/github.com/jpfielding/gorets/rets/ua_auth.go:32 +0x3da
  github.com/jpfielding/gorets/rets.(*UserAgentAuthentication).Request-fm()
      /var/www/html/support-chat/src/github.com/jpfielding/gorets/rets/client.go:72 +0x63
  github.com/jpfielding/gorets/rets.DefaultSession.func2()
      /var/www/html/support-chat/src/github.com/jpfielding/gorets/rets/client.go:78 +0x192
  main.(*retsSession).getMetadata()
      /var/www/html/support-chat/src/rets/retsvalues.go:189 +0x274
  main.main.func2()
      /var/www/html/support-chat/src/rets/retsvalues.go:107 +0x20c

Previous read at 0x00c420020110 by goroutine 28:
  runtime.convT2E()
      /home/gdv/.gvm/gos/go1.8.3/src/runtime/iface.go:191 +0x0
  github.com/jpfielding/gorets/rets.(*Digest).computeAuthorization()
      /var/www/html/support-chat/src/github.com/jpfielding/gorets/rets/digest.go:123 +0x85
  github.com/jpfielding/gorets/rets.(*Digest).CreateDigestResponse()
      /var/www/html/support-chat/src/github.com/jpfielding/gorets/rets/digest.go:151 +0xd2
  github.com/jpfielding/gorets/rets.(*WWWAuthTransport).header()
      /var/www/html/support-chat/src/github.com/jpfielding/gorets/rets/www_auth.go:25 +0x10b
  github.com/jpfielding/gorets/rets.(*WWWAuthTransport).Request()
      /var/www/html/support-chat/src/github.com/jpfielding/gorets/rets/www_auth.go:33 +0x8a
  github.com/jpfielding/gorets/rets.(*WWWAuthTransport).Request-fm()
      /var/www/html/support-chat/src/github.com/jpfielding/gorets/rets/client.go:64 +0x63
  github.com/jpfielding/gorets/rets.(*UserAgentAuthentication).Request()
      /var/www/html/support-chat/src/github.com/jpfielding/gorets/rets/ua_auth.go:32 +0x3da
  github.com/jpfielding/gorets/rets.(*UserAgentAuthentication).Request-fm()
      /var/www/html/support-chat/src/github.com/jpfielding/gorets/rets/client.go:72 +0x63
  github.com/jpfielding/gorets/rets.DefaultSession.func2()
      /var/www/html/support-chat/src/github.com/jpfielding/gorets/rets/client.go:78 +0x192
  main.(*retsSession).getMetadata()
      /var/www/html/support-chat/src/rets/retsvalues.go:189 +0x274
  main.main.func2()
      /var/www/html/support-chat/src/rets/retsvalues.go:107 +0x20c

Goroutine 25 (running) created at:
  main.main()
      /var/www/html/support-chat/src/rets/retsvalues.go:135 +0x7a3

Goroutine 28 (running) created at:
  main.main()
      /var/www/html/support-chat/src/rets/retsvalues.go:135 +0x7a3
==================
Found 1 data race(s)
```