### PR TITLE
Handle extra plaintext in logout

### DIFF
--- a/rets/logout.go
+++ b/rets/logout.go
@@ -72,7 +72,7 @@ func processResponseBody(body io.ReadCloser) (*LogoutResponse, error) {
 	values := map[string]string{}
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
-		if line == "" {
+		if line == "" || strings.Index(line,"=") == -1 {
 			continue
 		}
 		kv := strings.Split(line, "=")

--- a/rets/logout_test.go
+++ b/rets/logout_test.go
@@ -29,6 +29,25 @@ func TestProcessResponseBodyFull(t *testing.T) {
 	testutils.Equals(t, expected, actual)
 }
 
+func TestProcessResponseBodyFullWithExtraPlaintextDoesNotCrash(t *testing.T) {
+	actual, err := processResponseBody(
+		ioutil.NopCloser(strings.NewReader(
+			`<RETS ReplyCode="0" ReplyText="Success">
+									<RETS-RESPONSE>
+									Thank you for using our system that does not use SignOffMessage for some reason.
+									</RETS-RESPONSE>
+									</RETS>`,
+		)))
+
+	if err != nil {
+		t.Fail()
+	}
+
+	expected := &LogoutResponse{ReplyCode: 0, ReplyText: "Success"}
+
+	assert.Equal(t, expected, actual)
+}
+
 func TestProcessResponseBodyNoBilling(t *testing.T) {
 	actual, err := processResponseBody(
 		ioutil.NopCloser(strings.NewReader(


### PR DESCRIPTION
We're stuck for a little while on a many-months-old version of gorets, but we ran into this issue when integrating our first Trestle MLS.