### PR TITLE
Fixed typo in test file

### DIFF
--- a/explorer/client/test/specs/source.js
+++ b/explorer/client/test/specs/source.js
@@ -23,7 +23,7 @@ describe('goRets Explorer', () => {
       s.equalMulti(
         '#testpjohndoe-config-',
         ['id', 'loginurl', 'username', 'password', 'useragent', 'useragentpassword', 'proxy', 'version'],
-        ['testp:johndoe', 'http://www.fake.rets/login', 'johndoe', 'password', 'UserAgent', '', '', 'RETS/1.5'],
+        ['testp:johndoe', 'http://www.fake.rets/login', 'johndoe', 'password', 'UserAgent', '', '', 'RETS/1.5']
       );
     });
 


### PR DESCRIPTION
This extraneous comma caused _make frontend-test_ to fail.