### PR TITLE
Add dockerfile in root to enable better integration with CI/CD tools

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+vendor/
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+FROM golang:1.10 as golangBuilder
+
+RUN curl https://glide.sh/get | sh
+
+COPY . /go/src/github.com/jpfielding/gorets
+
+WORKDIR /go/src/github.com/jpfielding/gorets
+
+RUN make vendor build-explorer-svc
+
+# ==============
+
+FROM node:8.9 as nodeBuilder
+
+ARG HEADERS_CONFIG={}
+ARG CONFIG_ENV=docker
+ARG CONFIG_DOCKER="module.exports = { \
+  staticAssetPath: '.', \
+  api: '', \
+};"
+
+RUN echo ${CONFIG_ENV} "\n" ${CONFIG_DOCKER} "\n" ${HEADERS_CONFIG}
+
+COPY . /gorets
+
+WORKDIR /gorets/
+
+RUN echo ${CONFIG_DOCKER} >> explorer/client/config/docker.js
+RUN echo ${HEADERS_CONFIG} >> bin/explorer/config.json
+RUN make build-explorer-client
+
+# ==============
+
+FROM alpine
+
+RUN apk --update add ca-certificates
+EXPOSE 8080
+
+RUN mkdir -p /opt/explorer
+COPY --from=golangBuilder /go/src/github.com/jpfielding/gorets/bin/explorer/ /opt/explorer/
+COPY --from=nodeBuilder /gorets/bin/explorer/ /opt/explorer/
+RUN chmod +x /opt/explorer/explorer
+
+WORKDIR /opt/explorer
+
+ENTRYPOINT ["/bin/sh", "-c","./explorer -port 8080 -config ./config.json -react /opt/explorer"]
+CMD []

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,8 @@ COPY . /gorets
 WORKDIR /gorets/
 
 RUN echo ${CONFIG_DOCKER} >> explorer/client/config/docker.js
-RUN echo ${HEADERS_CONFIG} >> bin/explorer/config.json
 RUN make build-explorer-client
+RUN echo ${HEADERS_CONFIG} >> bin/explorer/config.json
 
 # ==============
 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,17 @@
 all: restore-deps test
 
 .PHONY: explorer
-explorer: build-explorer build-explorer-container
+explorer: build-explorer build-explorer-copy-files build-explorer-container
 
-build-explorer:
+build-explorer: build-explorer-svc build-explorer-client
+
+build-explorer-svc:
 	CGO_ENABLED=0 GOOS=linux go build -o bin/explorer/explorer cmds/explorer/*.go
-	cd explorer/client && npm install && CONFIG_ENV=docker npm run build
+
+build-explorer-client:
+	cd explorer/client && npm install && CONFIG_ENV=$(CONFIG_ENV) npm run build
+
+build-explorer-copy-files:
 	cp docker/explorer/Dockerfile bin/explorer
 	cp cmds/explorer/config.json bin/explorer
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+
+CONFIG_ENV ?= docker
+
 all: restore-deps test
 
 .PHONY: explorer

--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,7 @@ build-explorer-container:
 	docker build bin/explorer -t "gorets_explorer:latest"
 
 test-explorer:
-	CGO_ENABLED=0 GOOS=linux go build -o bin/explorer/explorer cmds/explorer/*.go
-	cd explorer/client && npm install && CONFIG_ENV=test npm run build
-	cp docker/explorer/Dockerfile bin/explorer
+	CONFIG_ENV=test make build-explorer-svc build-explorer-client build-explorer-copy-files
 	docker build bin/explorer -t "gorets_explorer_test:latest"
 
 vendor:

--- a/explorer/client/webpack.config.js
+++ b/explorer/client/webpack.config.js
@@ -11,7 +11,7 @@ const postcssImport = require('postcss-import');
 
 const config = require(`./config/${env}`);
 
-console.log(`Building gorets explorer with env: ${env} config: ${config}`);
+console.log(`Building gorets explorer with env: ${env} config: ${JSON.stringify(config, null, 2)}`);
 
 const definePlugin = new webpack.DefinePlugin({
   config: JSON.stringify(config),


### PR DESCRIPTION
A docker file in the root that takes care of building the desired production container by just passing the configuration as `--build-args` extends the flexibility of the repo.

Refactored makefile to reduce duplication in the file.

Fixed a logging statement in the `webpack.config.js`
