### PR TITLE
metadata: ensure we retain RETS ReplyCode when re-serializing response

### DIFF
--- a/pkg/metadata/system.go
+++ b/pkg/metadata/system.go
@@ -4,9 +4,9 @@ import "encoding/xml"
 
 // RETSResponseWrapper is a mapping that can be used directly with an xml.Decoder to extract a full mapping
 type RETSResponseWrapper struct {
-	XMLName   xml.Name `xml:"RETS,omitempty"`
-	ReplyCode int      `xml:",attr,omitempty"`
-	ReplyText string   `xml:",attr,omitempty"`
+	XMLName   xml.Name `xml:"RETS"`
+	ReplyCode int      `xml:",attr"`
+	ReplyText string   `xml:",attr"`
 	Metadata  Standard `xml:"METADATA,omitempty"`
 }
 

--- a/pkg/metadata/system_test.go
+++ b/pkg/metadata/system_test.go
@@ -13,16 +13,16 @@ import (
 var raw = `<?xml version="1.0" encoding="utf-8"?>
 <RETS ReplyCode="0" ReplyText="Operation Successful">
   <METADATA>
-	<METADATA-SYSTEM Version="01.72.11597" Date="2016-07-21T20:49:13">
-	  <SYSTEM SystemID="ABBA" SystemDescription="abba" TimeZoneOffset="-04:00">
-		<METADATA-RESOURCE Version="01.72.11597" Date="2016-07-21T20:49:13" System="ABBA">
-		  <Resource>
-			<ResourceID>Property</ResourceID>
-		  </Resource>
-		</METADATA-RESOURCE>
-	  </SYSTEM>
-	</METADATA-SYSTEM>
-</METADATA>
+		<METADATA-SYSTEM Version="01.72.11597" Date="2016-07-21T20:49:13">
+	  	<SYSTEM SystemID="ABBA" SystemDescription="abba" TimeZoneOffset="-04:00">
+				<METADATA-RESOURCE Version="01.72.11597" Date="2016-07-21T20:49:13" System="ABBA">
+		  		<Resource>
+						<ResourceID>Property</ResourceID>
+		  		</Resource>
+				</METADATA-RESOURCE>
+	  	</SYSTEM>
+		</METADATA-SYSTEM>
+	</METADATA>
 </RETS>`
 
 func TestLoad(t *testing.T) {
@@ -58,4 +58,33 @@ func TestSystem(t *testing.T) {
 	}
 	assert.Equal(t, "ABBA", xml.System.ID)
 	assert.Equal(t, "Property", string(xml.System.MResource.Resource[0].ResourceID))
+}
+
+// TestResponseSerializeXML verifies that we don't accidentally lose the most
+// common RETS reply status code, 0, which Golang drops with "omitempty"
+// since it is the "zero value" for the field.
+// RETS 1.8 - 3.5: ReplyCode is required at top-level for all RETS responses
+func TestResponseSerializeXML(t *testing.T) {
+	// Setup
+	var raw = `<?xml version="1.0" encoding="utf-8"?>
+	<RETS ReplyCode="0" ReplyText="Operation Successful">
+		<METADATA><METADATA-SYSTEM><SYSTEM></SYSTEM></METADATA-SYSTEM></METADATA>
+	</RETS>`
+	body := ioutil.NopCloser(strings.NewReader(raw))
+	defer body.Close()
+	parser := xml.NewDecoder(body)
+	retsResponse := RETSResponseWrapper{}
+	err := parser.Decode(&retsResponse)
+	if err != io.EOF {
+		assert.Nil(t, err)
+	}
+	// Sanity check
+	assert.Equal(t, 0, retsResponse.ReplyCode)
+
+	// Re-serialize to XML, verify we still have our ReplyCode
+	bytes, err := xml.Marshal(retsResponse)
+	assert.Nil(t, err)
+	serializedResponse := string(bytes)
+
+	assert.Contains(t, serializedResponse, "ReplyCode=\"0\"")
 }


### PR DESCRIPTION
Bug: when re-serializing the top-level RETS metadata of a _successful_ response, gorets strips out the required `ReplyCode` attribute. This is because the `xml` struct tag contains `omitempty`, which treats the success replycode - zero, the _literal_ "zero value" - as an empty value for type `int`.

Per RETS 1.8 - 3.5, `ReplyCode` is a required attribute of the `<RETS>` element.

This PR changes the serialization rules for `metadata.RETSResponseWrapper` to ensure that `ReplyCode` attribute is always written.